### PR TITLE
Updated install.sh for gedit 3.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -v
 
-sudo cp ./*.xml $HOME/.gnome2/gedit/styles/.
+sudo cp ./*.xml /usr/share/gtksourceview-3.0/styles/.


### PR DESCRIPTION
I updated the install script to be able to install files for gedit 3. I tested this with version 3.6.2 and it worked very well the first time. It should also be noted that sudo IS required in this case due to the file's location within the system. Test on Ubuntu 13.04, with gEdit 3.6.2.
