### PR TITLE
Use the modern theme location in the intaller

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -v
 
-mkdir -p $HOME/.gnome2/gedit/styles
-cp ./*.xml $HOME/.gnome2/gedit/styles/.
+install_dir=$HOME/.local/share/gedit/styles
+mkdir -p $install_dir
+cp ./*.xml $install_dir

--- a/slush_and_poppies.xml
+++ b/slush_and_poppies.xml
@@ -43,6 +43,8 @@
 <!-- Global Settings -->
 
   <style name="text" foreground="black" background="off_white"/>
+  <style name="selection" background="medium_grey"/>
+  <style name="selection-unfocused" background="light_grey"/>
   <style name="cursor" foreground="black"/>
   <style name="current-line" background="light_grey"/>
   <style name="line-numbers" foreground="dark_grey" background="off_white"/>


### PR DESCRIPTION
Modern versions of gedit place their themes in ~/.local/share/gedit/styles.

This is part of a long-running project to clean up the random dotfiles in the user's home directory and consolidate everything under one desktop-neutral location.
