### PR TITLE
Makefile rule for gedit2/3 installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+#!/usr/bin/make --no-print-directory
+
+.ONESHELL:
+all: gedit3
+	@$(MAKE) -s done
+
+gedit3:
+	@mkdir -p ${HOME}/.local/share/gedit/styles
+	@cp -v *.xml ${HOME}/.local/share/gedit/styles
+
+gedit2:
+	@mkdir -p ${HOME}/.gnome2/gedit/styles
+	@cp -v *.xml ${HOME}/.gnome2/gedit/styles/.
+
+done:
+	@echo installation done!


### PR DESCRIPTION
By default, it installs all styles for gedit3; however, there is a different rule for gedit2 installation.